### PR TITLE
Move the plugin specific layers to the bottom

### DIFF
--- a/container-images/foreman/Containerfile
+++ b/container-images/foreman/Containerfile
@@ -2,14 +2,9 @@ FROM quay.io/centos/centos:stream9
 
 ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
-ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello"
 
 RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install foreman foreman-postgresql foreman-service foreman-redis foreman-dynflow-sidekiq --nodocs -y && dnf clean all
 
-RUN for PLUGIN in ${FOREMAN_PLUGINS}; do echo $PLUGIN; dnf install --nodocs -y "rubygem($PLUGIN)"; echo "gem '$PLUGIN' if ENV.fetch('FOREMAN_ENABLED_PLUGINS', '').split.include?('$PLUGIN') || ENV.fetch('FOREMAN_ENABLED_PLUGINS', nil).nil?" > /usr/share/foreman/bundler.d/$PLUGIN.rb; done && \
-    dnf clean all
-
-USER foreman
 WORKDIR /usr/share/foreman
 ENV MALLOC_ARENA_MAX=2
 ENV FOREMAN_BIND=0.0.0.0
@@ -17,3 +12,10 @@ ENV RAILS_SERVE_STATIC_FILES=true
 ENV RAILS_ENV=production
 CMD /usr/share/foreman/bin/rails db:migrate && /usr/share/foreman/bin/rails db:seed && /usr/share/foreman/bin/rails server --environment production
 EXPOSE 3000/tcp
+
+ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello"
+
+RUN for PLUGIN in ${FOREMAN_PLUGINS}; do echo $PLUGIN; dnf install --nodocs -y "rubygem($PLUGIN)"; echo "gem '$PLUGIN' if ENV.fetch('FOREMAN_ENABLED_PLUGINS', '').split.include?('$PLUGIN') || ENV.fetch('FOREMAN_ENABLED_PLUGINS', nil).nil?" > /usr/share/foreman/bundler.d/$PLUGIN.rb; done && \
+    dnf clean all
+
+USER foreman


### PR DESCRIPTION
This allows reusing the base layers in case you build multiple variations.

Currently untested and submitting for early review. If this is a good idea, we should also apply it to foreman-proxy.