### PR TITLE
Remove PostgreSQL PORT setting

### DIFF
--- a/roles/pulp/templates/settings.py.j2
+++ b/roles/pulp/templates/settings.py.j2
@@ -11,7 +11,6 @@ DATABASES = {
 		'USER': 'pulp',
 		'PASSWORD': '{{ pulp_db_password }}',
 		'HOST': 'localhost',
-		'PORT': '',
 	}
 }
 


### PR DESCRIPTION
Based on discussion: https://github.com/theforeman/foreman-quadlet/pull/34#discussion_r1843496880

The `PORT` setting in the database configuration is redundant because Django defaults to the PostgreSQL standard port (`5432`) when the `PORT` setting is omitted.

Reference: https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-PORT