### PR TITLE
use a dedicated "server" fixture, instead of the generic "host"

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 vagrant ssh-config > .vagrant/ssh-config
-py.test -vv --hosts=quadlet --sudo --ssh-config=.vagrant/ssh-config tests/*_test.py
+py.test -vv tests/*_test.py

--- a/tests/candlepin_test.py
+++ b/tests/candlepin_test.py
@@ -1,45 +1,45 @@
 import re
 
 
-def assert_secret_content(host, secret_name, secret_value):
-    secret = host.run(f'podman secret inspect --format {"{{.SecretData}}"} --showsecret {secret_name}')
+def assert_secret_content(server, secret_name, secret_value):
+    secret = server.run(f'podman secret inspect --format {"{{.SecretData}}"} --showsecret {secret_name}')
     assert secret.succeeded
     assert secret.stdout.strip() == secret_value
 
 
-def test_candlepin_service(host):
-    candlepin = host.service("candlepin")
+def test_candlepin_service(server):
+    candlepin = server.service("candlepin")
     assert candlepin.is_running
     assert candlepin.is_enabled
 
 
-def test_candlepin_port(host):
-    candlepin = host.addr("localhost")
+def test_candlepin_port(server):
+    candlepin = server.addr("localhost")
     assert candlepin.port("23443").is_reachable
 
 
-def test_candlepin_status(host):
-    status = host.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://localhost:23443/candlepin/status')
+def test_candlepin_status(server):
+    status = server.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://localhost:23443/candlepin/status')
     assert status.succeeded
     assert status.stdout == '200'
 
 
-def test_artemis_port(host):
-    candlepin = host.addr("localhost")
+def test_artemis_port(server):
+    candlepin = server.addr("localhost")
     assert candlepin.port("61613").is_reachable
 
 
-def test_artemis_auth(host):
-    cmd = host.run('echo "" | openssl s_client -CAfile /root/certificates/certs/ca.crt -cert /root/certificates/certs/quadlet.example.com-client.crt -key /root/certificates/private/quadlet.example.com-client.key -connect localhost:61613')
+def test_artemis_auth(server):
+    cmd = server.run('echo "" | openssl s_client -CAfile /root/certificates/certs/ca.crt -cert /root/certificates/certs/quadlet.example.com-client.crt -key /root/certificates/private/quadlet.example.com-client.key -connect localhost:61613')
     assert cmd.succeeded, f"exit: {cmd.rc}\n\nstdout:\n{cmd.stdout}\n\nstderr:\n{cmd.stderr}"
 
 
-def test_certs_users_file(host):
-    assert_secret_content(host, 'candlepin-artemis-cert-users-properties', 'katelloUser=CN=quadlet.example.com, O=Foreman, ST=NC, C=US')
+def test_certs_users_file(server):
+    assert_secret_content(server, 'candlepin-artemis-cert-users-properties', 'katelloUser=CN=quadlet.example.com, O=Foreman, ST=NC, C=US')
 
 
-def test_tls(host):
-    result = host.run('nmap --script +ssl-enum-ciphers localhost -p 23443')
+def test_tls(server):
+    result = server.run('nmap --script +ssl-enum-ciphers localhost -p 23443')
     result = result.stdout
     # We don't enable TLSv1.3 by default yet. TLSv1.3 support was added in tomcat 7.0.92
     # But tomcat 7.0.76 is the latest version available on EL7
@@ -56,5 +56,5 @@ def test_tls(host):
     assert "least strength: A" in result
 
 
-def test_cert_roles(host):
-    assert_secret_content(host, 'candlepin-artemis-cert-roles-properties', 'candlepinEventsConsumer=katelloUser')
+def test_cert_roles(server):
+    assert_secret_content(server, 'candlepin-artemis-cert-roles-properties', 'candlepinEventsConsumer=katelloUser')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import testinfra
+
+
+@pytest.fixture(scope="module")
+def server():
+    yield testinfra.get_host('paramiko://quadlet', sudo=True, ssh_config='./.vagrant/ssh-config')

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -8,23 +8,23 @@ FOREMAN_PROXY_PORT = 9090
 
 
 @pytest.fixture(scope="module")
-def foreman_proxy_version_curl(host):
-    return host.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/version")
+def foreman_proxy_version_curl(server):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/version")
 
 
 @pytest.fixture(scope="module")
-def foreman_proxy_features_curl(host):
-    return host.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --cert /root/certificates/certs/quadlet.example.com-client.crt --key /root/certificates/private/quadlet.example.com-client.key https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/v2/features")
+def foreman_proxy_features_curl(server):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --cert /root/certificates/certs/quadlet.example.com-client.crt --key /root/certificates/private/quadlet.example.com-client.key https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/v2/features")
 
 
-def test_foreman_proxy_service(host):
-    foreman_proxy = host.service("foreman-proxy")
+def test_foreman_proxy_service(server):
+    foreman_proxy = server.service("foreman-proxy")
     assert foreman_proxy.is_running
     assert foreman_proxy.is_enabled
 
 
-def test_foreman_proxy_port(host):
-    foreman_proxy = host.addr(FOREMAN_PROXY_HOST)
+def test_foreman_proxy_port(server):
+    foreman_proxy = server.addr(FOREMAN_PROXY_HOST)
     assert foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable
 
 

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -8,8 +8,8 @@ FOREMAN_PORT = 3000
 
 
 @pytest.fixture(scope="module")
-def foreman_status_curl(host):
-    return host.run(f"curl --silent --write-out '%{{stderr}}%{{http_code}}' http://{FOREMAN_HOST}:{FOREMAN_PORT}/api/v2/ping")
+def foreman_status_curl(server):
+    return server.run(f"curl --silent --write-out '%{{stderr}}%{{http_code}}' http://{FOREMAN_HOST}:{FOREMAN_PORT}/api/v2/ping")
 
 
 @pytest.fixture(scope="module")
@@ -17,14 +17,14 @@ def foreman_status(foreman_status_curl):
     return json.loads(foreman_status_curl.stdout)
 
 
-def test_foreman_service(host):
-    foreman = host.service("foreman")
+def test_foreman_service(server):
+    foreman = server.service("foreman")
     assert foreman.is_running
     assert foreman.is_enabled
 
 
-def test_foreman_port(host):
-    foreman = host.addr(FOREMAN_HOST)
+def test_foreman_port(server):
+    foreman = server.addr(FOREMAN_HOST)
     assert foreman.port(FOREMAN_PORT).is_reachable
 
 
@@ -50,14 +50,14 @@ def test_katello_services_status(foreman_status, katello_service):
 
 
 @pytest.mark.parametrize("dynflow_instance", ['orchestrator', 'worker', 'worker-hosts-queue'])
-def test_foreman_dynflow_container_instances(host, dynflow_instance):
-    file = host.file(f"/etc/containers/systemd/dynflow-sidekiq@{dynflow_instance}.container")
+def test_foreman_dynflow_container_instances(server, dynflow_instance):
+    file = server.file(f"/etc/containers/systemd/dynflow-sidekiq@{dynflow_instance}.container")
     assert file.exists
     assert file.is_symlink
 
 
 @pytest.mark.parametrize("dynflow_instance", ['orchestrator', 'worker', 'worker-hosts-queue'])
-def test_foreman_dynflow_service_instances(host, dynflow_instance):
-    service = host.service(f"dynflow-sidekiq@{dynflow_instance}")
+def test_foreman_dynflow_service_instances(server, dynflow_instance):
+    service = server.service(f"dynflow-sidekiq@{dynflow_instance}")
     assert service.is_running
     assert service.is_enabled

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -3,41 +3,41 @@ HTTP_PORT = 80
 HTTPS_PORT = 443
 
 
-def test_httpd_service(host):
-    httpd = host.service("httpd")
+def test_httpd_service(server):
+    httpd = server.service("httpd")
     assert httpd.is_running
     assert httpd.is_enabled
 
 
-def test_http_port(host):
-    httpd = host.addr(HTTP_HOST)
+def test_http_port(server):
+    httpd = server.addr(HTTP_HOST)
     assert httpd.port(HTTP_PORT).is_reachable
 
 
-def test_https_port(host):
-    httpd = host.addr(HTTP_HOST)
+def test_https_port(server):
+    httpd = server.addr(HTTP_HOST)
     assert httpd.port(HTTPS_PORT).is_reachable
 
 
-def test_https_foreman_ping(host):
-    cmd = host.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/api/v2/ping')
+def test_https_foreman_ping(server):
+    cmd = server.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/api/v2/ping')
     assert cmd.succeeded
     assert cmd.stdout == '200'
 
 
-def test_https_pulp_status(host):
-    cmd = host.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/pulp/api/v3/status/')
+def test_https_pulp_status(server):
+    cmd = server.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/pulp/api/v3/status/')
     assert cmd.succeeded
     assert cmd.stdout == '200'
 
 
-def test_https_pulp_content(host):
-    cmd = host.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/pulp/content/')
+def test_https_pulp_content(server):
+    cmd = server.run('curl --cacert /root/certificates/certs/ca.crt --silent --output /dev/null --write-out \'%{http_code}\' https://quadlet.example.com/pulp/content/')
     assert cmd.succeeded
     assert cmd.stdout == '200'
 
 
-def test_https_pulp_auth(host):
-    cmd = host.run(f"curl --cacert /root/certificates/certs/ca.crt --silent --write-out '%{{stderr}}%{{http_code}}' --cert /root/certificates/certs/quadlet.example.com-client.crt --key /root/certificates/private/quadlet.example.com-client.key https://quadlet.example.com/pulp/api/v3/users/")
+def test_https_pulp_auth(server):
+    cmd = server.run(f"curl --cacert /root/certificates/certs/ca.crt --silent --write-out '%{{stderr}}%{{http_code}}' --cert /root/certificates/certs/quadlet.example.com-client.crt --key /root/certificates/private/quadlet.example.com-client.key https://quadlet.example.com/pulp/api/v3/users/")
     assert cmd.succeeded
     assert cmd.stderr == '200'

--- a/tests/postgresql_test.py
+++ b/tests/postgresql_test.py
@@ -1,9 +1,9 @@
-def test_postgresql_service(host):
-    postgresql = host.service("postgresql")
+def test_postgresql_service(server):
+    postgresql = server.service("postgresql")
     assert postgresql.is_running
     assert postgresql.is_enabled
 
 
-def test_postgresql_port(host):
-    postgresql = host.addr("localhost")
+def test_postgresql_port(server):
+    postgresql = server.addr("localhost")
     assert postgresql.port("5432").is_reachable

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -6,34 +6,34 @@ PULP_API_PORT = 24817
 PULP_CONTENT_PORT = 24816
 
 @pytest.fixture(scope="module")
-def pulp_status_curl(host):
-    return host.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/status/")
+def pulp_status_curl(server):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/status/")
 
 @pytest.fixture(scope="module")
 def pulp_status(pulp_status_curl):
     return json.loads(pulp_status_curl.stdout)
 
-def test_pulp_api_service(host):
-    pulp_api = host.service("pulp-api")
+def test_pulp_api_service(server):
+    pulp_api = server.service("pulp-api")
     assert pulp_api.is_running
     assert pulp_api.is_enabled
 
-def test_pulp_content_service(host):
-    pulp_content = host.service("pulp-content")
+def test_pulp_content_service(server):
+    pulp_content = server.service("pulp-content")
     assert pulp_content.is_running
     assert pulp_content.is_enabled
 
-def test_pulp_worker_service(host):
-    pulp_worker = host.service("pulp-worker")
+def test_pulp_worker_service(server):
+    pulp_worker = server.service("pulp-worker")
     assert pulp_worker.is_running
     assert pulp_worker.is_enabled
 
-def test_pulp_api_port(host):
-    pulp_api = host.addr(PULP_HOST)
+def test_pulp_api_port(server):
+    pulp_api = server.addr(PULP_HOST)
     assert pulp_api.port(PULP_API_PORT).is_reachable
 
-def test_pulp_content_port(host):
-    pulp_content = host.addr(PULP_HOST)
+def test_pulp_content_port(server):
+    pulp_content = server.addr(PULP_HOST)
     assert pulp_content.port(PULP_CONTENT_PORT).is_reachable
 
 def test_pulp_status(pulp_status_curl):
@@ -60,10 +60,10 @@ def test_pulp_status_workers(pulp_status):
     assert pulp_status['online_workers']
 
 @pytest.mark.xfail(reason='password auth is deactivated when we use cert auth')
-def test_pulp_admin_auth(host):
-    cmd = host.run(f"curl --silent --write-out '%{{stderr}}%{{http_code}}' --user admin:CHANGEME http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/users/")
+def test_pulp_admin_auth(server):
+    cmd = server.run(f"curl --silent --write-out '%{{stderr}}%{{http_code}}' --user admin:CHANGEME http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/users/")
     assert cmd.succeeded
     assert cmd.stderr == '200'
 
-def test_pulp_volumes(host):
-    assert host.file("/var/lib/pulp").is_directory
+def test_pulp_volumes(server):
+    assert server.file("/var/lib/pulp").is_directory

--- a/tests/redis_test.py
+++ b/tests/redis_test.py
@@ -5,12 +5,12 @@ REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 
 
-def test_redis_service(host):
-    redis = host.service("redis")
+def test_redis_service(server):
+    redis = server.service("redis")
     assert redis.is_running
     assert redis.is_enabled
 
 
-def test_redis_port(host):
-    redis = host.addr(REDIS_HOST)
+def test_redis_port(server):
+    redis = server.addr(REDIS_HOST)
     assert redis.port(REDIS_PORT).is_reachable


### PR DESCRIPTION
this allows differentiating different types of hosts which we will have soon
