### PR TITLE
migrate httpd installation from rpm to container-based

### DIFF
--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -1,4 +1,7 @@
-httpd_ssl_dir: /etc/pki/httpd
+httpd_ssl_dir: /etc/httpd/ssl
+httpd_conf_dir: /etc/foreman-quadlet/httpd
+httpd_log_dir: /var/log/httpd
+httpd_container_image: registry.access.redhat.com/ubi9/httpd-24:latest
 httpd_pulp_api_backend: http://localhost:24817
 httpd_pulp_content_backend: http://localhost:24816
 httpd_foreman_backend: http://localhost:3000

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -34,8 +34,13 @@
 - name: Configure foreman-ssl vhost
   ansible.builtin.template:
     src: foreman-ssl-vhost.conf.j2
-    dest: /etc/httpd/conf.d/foreman-ssl.conf
+    dest: "{{ httpd_conf_dir }}/foreman-ssl.conf"
     mode: "0644"
+
+- name: Disable welcome page in container
+  ansible.builtin.file:
+    path: "{{ httpd_conf_dir }}/welcome.conf"
+    state: absent
 
 - name: Run Apache as a container
   containers.podman.podman_container:
@@ -49,8 +54,3 @@
     ports:
       - "80:80"
       - "443:443"
-
-- name: Disable welcome page in container
-  containers.podman.podman_container_exec:
-    name: httpd
-    command: rm -f /etc/httpd/conf.d/welcome.conf

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -4,10 +4,12 @@
     name: "{{ httpd_container_image }}"
     state: present
 
-- name: Create cert directories
+- name: Create required directories
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    owner: root
+    group: root
     mode: "0750"
   loop:
     - "{{ httpd_ssl_dir }}/certs"
@@ -54,3 +56,5 @@
     ports:
       - "80:80"
       - "443:443"
+    env:
+      HTTP_LOG_TO_VOLUME: "1"

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -4,11 +4,6 @@
     name: "{{ httpd_container_image }}"
     state: present
 
-- name: Disable welcome page in container
-  containers.podman.podman_container_exec:
-    container: httpd
-    command: rm -f /etc/httpd/conf.d/welcome.conf
-
 - name: Create cert directories
   ansible.builtin.file:
     path: "{{ item }}"
@@ -54,3 +49,8 @@
     ports:
       - "80:80"
       - "443:443"
+
+- name: Disable welcome page in container
+  containers.podman.podman_container_exec:
+    name: httpd
+    command: rm -f /etc/httpd/conf.d/welcome.conf

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
 - name: Pull Apache container image
   containers.podman.podman_image:
-    name: registry.access.redhat.com/ubi9/httpd-24:latest
+    name: "{{ httpd_container_image }}"
     state: present
+
+- name: Disable welcome page in container
+  containers.podman.podman_container_exec:
+    container: httpd
+    command: rm -f /etc/httpd/conf.d/welcome.conf
 
 - name: Create cert directories
   ansible.builtin.file:
@@ -12,6 +17,8 @@
   loop:
     - "{{ httpd_ssl_dir }}/certs"
     - "{{ httpd_ssl_dir }}/private"
+    - "{{ httpd_conf_dir }}"
+    - "{{ httpd_log_dir }}"
 
 - name: Deploy certificates
   ansible.builtin.copy:
@@ -37,13 +44,13 @@
 
 - name: Run Apache as a container
   containers.podman.podman_container:
-    name: apache
-    image: registry.access.redhat.com/ubi9/httpd-24:latest
+    name: httpd
+    image: "{{ httpd_container_image }}"
     state: started
     volumes:
       - "{{ httpd_ssl_dir }}:/etc/httpd/ssl"
-      - "/etc/httpd/conf.d:/usr/local/apache2/conf.d"
-      - "/var/log/httpd:/usr/local/apache2/logs"
+      - "{{ httpd_conf_dir }}:/etc/httpd/conf.d"
+      - "{{ httpd_log_dir }}:/usr/local/apache2/logs"
     ports:
       - "80:80"
       - "443:443"

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -1,21 +1,8 @@
 ---
-- name: Install Apache httpd
-  ansible.builtin.package:
-    name:
-      - httpd
-      - mod_ssl
+- name: Pull Apache container image
+  containers.podman.podman_image:
+    name: registry.access.redhat.com/ubi9/httpd-24:latest
     state: present
-
-- name: Set httpd_can_network_connect so Apache can connect to Puma and Gunicorn
-  ansible.posix.seboolean:
-    name: httpd_can_network_connect
-    state: true
-    persistent: true
-
-- name: Disable welcome page
-  ansible.builtin.file:
-    path: /etc/httpd/conf.d/welcome.conf
-    state: absent
 
 - name: Create cert directories
   ansible.builtin.file:
@@ -48,8 +35,15 @@
     dest: /etc/httpd/conf.d/foreman-ssl.conf
     mode: "0644"
 
-- name: Start Apache httpd
-  ansible.builtin.service:
-    name: httpd
+- name: Run Apache as a container
+  containers.podman.podman_container:
+    name: apache
+    image: registry.access.redhat.com/ubi9/httpd-24:latest
     state: started
-    enabled: true
+    volumes:
+      - "{{ httpd_ssl_dir }}:/etc/httpd/ssl"
+      - "/etc/httpd/conf.d:/usr/local/apache2/conf.d"
+      - "/var/log/httpd:/usr/local/apache2/logs"
+    ports:
+      - "80:80"
+      - "443:443"

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -20,12 +20,12 @@
 
   ## SSL directives
   SSLEngine on
-  SSLCertificateFile      "{{ httpd_ssl_dir }}/certs/katello-apache.crt"
-  SSLCertificateKeyFile   "{{ httpd_ssl_dir }}/private/katello-apache.key"
-  SSLCertificateChainFile "{{ httpd_ssl_dir }}/certs/katello-server-ca.crt"
+  SSLCertificateFile      "/etc/httpd/ssl/certs/katello-apache.crt"
+  SSLCertificateKeyFile   "/etc/httpd/ssl/private/katello-apache.key"
+  SSLCertificateChainFile "/etc/httpd/ssl/certs/katello-server-ca.crt"
   SSLVerifyClient         optional
   SSLVerifyDepth          3
-  SSLCACertificateFile    "{{ httpd_ssl_dir }}/certs/katello-default-ca.crt"
+  SSLCACertificateFile    "/etc/httpd/ssl/certs/katello-default-ca.crt"
   SSLOptions +StdEnvVars +ExportCertData
 
   # SSL Proxy directives

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -20,12 +20,12 @@
 
   ## SSL directives
   SSLEngine on
-  SSLCertificateFile      "/etc/httpd/ssl/certs/katello-apache.crt"
-  SSLCertificateKeyFile   "/etc/httpd/ssl/private/katello-apache.key"
-  SSLCertificateChainFile "/etc/httpd/ssl/certs/katello-server-ca.crt"
+  SSLCertificateFile      "{{ httpd_ssl_dir }}/certs/katello-apache.crt"
+  SSLCertificateKeyFile   "{{ httpd_ssl_dir }}/private/katello-apache.key"
+  SSLCertificateChainFile "{{ httpd_ssl_dir }}/certs/katello-server-ca.crt"
   SSLVerifyClient         optional
   SSLVerifyDepth          3
-  SSLCACertificateFile    "/etc/httpd/ssl/certs/katello-default-ca.crt"
+  SSLCACertificateFile    "{{ httpd_ssl_dir }}/certs/katello-default-ca.crt"
   SSLOptions +StdEnvVars +ExportCertData
 
   # SSL Proxy directives

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -4,10 +4,8 @@ HTTPS_PORT = 443
 
 
 def test_httpd_service(server):
-    httpd = server.service("httpd")
-    assert httpd.is_running
-    assert httpd.is_enabled
-
+    apache = server.podman_container("apache")
+    assert apache.is_running
 
 def test_http_port(server):
     httpd = server.addr(HTTP_HOST)

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -4,8 +4,8 @@ HTTPS_PORT = 443
 
 
 def test_httpd_service(server):
-    apache = server.podman_container("apache")
-    assert apache.is_running
+    httpd = server.podman_container("httpd")
+    assert httpd.is_running
 
 def test_http_port(server):
     httpd = server.addr(HTTP_HOST)


### PR DESCRIPTION
This PR transitions the `httpd` setup from an RPM-based installation to a containerized deployment using the [ubi9/httpd-24](https://catalog.redhat.com/software/containers/ubi9/httpd-24/61a60c3e3e9240fca360f74a) image.