### PR TITLE
Build redis container image based on CentOS Stream 9

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,6 +30,7 @@ jobs:
           - candlepin
           - foreman
           - foreman-proxy
+          - redis
     steps:
       - uses: actions/checkout@v4
       - name: Build ${{ matrix.container }} container

--- a/container-images/redis/Containerfile
+++ b/container-images/redis/Containerfile
@@ -1,0 +1,6 @@
+FROM quay.io/centos/centos:stream9
+RUN dnf -y update && \
+    dnf -y install redis && \
+    dnf clean all
+EXPOSE 6379
+CMD ["redis-server", "--protected-mode", "no"]

--- a/container-images/redis/Makefile
+++ b/container-images/redis/Makefile
@@ -1,0 +1,8 @@
+IMAGE_NAME=quay.io/akumari/redis-rpm
+IMAGE_TAG=nightly
+
+build:
+	podman build -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+push:
+	podman push ${IMAGE_NAME}:${IMAGE_TAG}


### PR DESCRIPTION
Fixes https://github.com/theforeman/foreman-quadlet/issues/94

Uses [quay.io/akumari/redis-rpm:nightly](https://quay.io/repository/akumari/redis-rpm) as the image name and tag.