### PR TITLE
always run k-c-c, even in check mode

### DIFF
--- a/roles/certificate_checks/tasks/main.yml
+++ b/roles/certificate_checks/tasks/main.yml
@@ -18,3 +18,4 @@
       - "-b"
       - "{{ certificate_checks_ca }}"
   changed_when: false
+  check_mode: false


### PR DESCRIPTION
the command doesn't alter the system and executing it allows to see if
the certs are valid w/o risking any changes to the system
