### PR TITLE
Add playbook to pre-pull images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run setup
         run: |
           ansible-playbook playbooks/setup.yaml
+      - name: Run image pull
+        run: |
+          ansible-playbook playbooks/images.yaml
       - name: Run deployment
         run: |
           ansible-playbook playbooks/deploy.yaml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ inventory = vagrant.py
 stdout_callback=debug
 stderr_callback=debug
 roles_path = ~/.ansible/roles:./roles
+callbacks_enabled = profile_tasks

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -5,6 +5,7 @@
   become: true
   vars_files:
     - "../vars/{{ certificate_source }}_certificates.yml"
+    - "../vars/images.yml"
   vars:
     certificate_source: default
     certificates_hostnames:

--- a/playbooks/images.yaml
+++ b/playbooks/images.yaml
@@ -1,0 +1,12 @@
+---
+- name: Pull images
+  hosts:
+    - quadlet
+  vars_files:
+    - "../vars/images.yml"
+  become: true
+  tasks:
+    - name: Pull an image
+      containers.podman.podman_image:
+        name: "{{ item }}"
+      loop: "{{ images }}"

--- a/vars/images.yml
+++ b/vars/images.yml
@@ -1,0 +1,15 @@
+candlepin_container_image: quay.io/ehelms/candlepin
+candlepin_container_tag: 4.4.14
+foreman_container_image: "quay.io/evgeni/foreman-rpm"
+foreman_container_tag: "nightly"
+foreman_proxy_container_image: "quay.io/evgeni/foreman-proxy-rpm"
+foreman_proxy_container_tag: "nightly"
+pulp_image: quay.io/pulp/pulp-minimal:3.63
+redis_image: quay.io/sclorg/redis-6-c9s:latest
+
+images:
+ - "{{ candlepin_container_image }}:{{ candlepin_container_tag }}"
+ - "{{ foreman_container_image }}:{{ foreman_container_tag }}"
+ - "{{ foreman_proxy_container_image }}:{{ foreman_proxy_container_tag }}"
+ - "{{ pulp_image }}"
+ - "{{ redis_image }}"


### PR DESCRIPTION
Pre-pulling the images isn't necessary, but can help differentiate the runtime of the actual installer part vs. image pull.