### PR TITLE
Use Candlepin project official image

### DIFF
--- a/roles/candlepin/defaults/main.yml
+++ b/roles/candlepin/defaults/main.yml
@@ -12,11 +12,13 @@ candlepin_ciphers:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
-candlepin_container_image: quay.io/ehelms/candlepin
-candlepin_container_tag: 4.4.14
+candlepin_container_image: quay.io/candlepin/candlepin
+candlepin_container_tag: 4.4.20-1
 
 candlepin_db_host: localhost
 candlepin_db_port: 5432
 candlepin_db_ssl: false
 candlepin_db_ssl_ca: None
 candlepin_db_ssl_verify: true
+
+candlepin_tomcat_home: /opt/tomcat

--- a/roles/candlepin/tasks/artemis.yml
+++ b/roles/candlepin/tasks/artemis.yml
@@ -26,13 +26,12 @@
       filename: login.config
       app: artemis
 
-- name: Create Tomcat jaas.conf
+- name: Create the podman secret for the catalina_opts
   containers.podman.podman_secret:
     state: present
-    name: candlepin-artemis-jaas-conf
-    data: "{{ lookup('ansible.builtin.template', 'jaas.conf') }}"
+    name: candlepin-artemis-catalina-opts
+    data: "-Djava.security.auth.login.config=/opt/tomcat/conf/login.config"
     labels:
-      filename: jaas.conf
       app: artemis
 
 - name: Create Tomcat cert-roles.properties

--- a/roles/candlepin/tasks/main.yml
+++ b/roles/candlepin/tasks/main.yml
@@ -57,22 +57,21 @@
     state: quadlet
     network: host
     hostname: "{{ ansible_fqdn }}"
+    expose:
+      - 23443
+      - 61613
     secrets:
-      - 'candlepin-ca-cert,target=/etc/candlepin/certs/candlepin-ca.crt,mode=0440,type=mount'
-      - 'candlepin-ca-key,target=/etc/candlepin/certs/candlepin-ca.key,mode=0440,type=mount'
-      - 'candlepin-tomcat-keystore,target=/etc/candlepin/certs/keystore,mode=0440,type=mount'
-      - 'candlepin-tomcat-truststore,target=/etc/candlepin/certs/truststore,mode=0440,type=mount'
-      - 'candlepin-candlepin-conf,target=/etc/candlepin/candlepin.conf,mode=0440,type=mount'
-      - 'candlepin-artemis-broker-xml,target=/etc/candlepin/broker.xml,mode=440,type=mount'
-      - 'candlepin-tomcat-server-xml,target=/etc/tomcat/server.xml,mode=440,type=mount'
-      - 'candlepin-tomcat-conf,target=/etc/tomcat/tomcat.conf,mode=440,type=mount'
-      - 'candlepin-artemis-login-config,target=/etc/tomcat/login.config,mode=440,type=mount'
-      - 'candlepin-artemis-cert-roles-properties,target=/etc/tomcat/cert-roles.properties,mode=440,type=mount'
-      - 'candlepin-artemis-cert-users-properties,target=/etc/tomcat/cert-users.properties,mode=440,type=mount'
-      - 'candlepin-artemis-jaas-conf,target=/etc/tomcat/conf.d/jaas.conf,mode=440,type=mount'
-    volumes:
-      - /var/log/candlepin:/var/log/candlepin:Z
-      - /var/log/tomcat:/var/log/tomcat:Z
+      - "candlepin-ca-cert,target=/etc/candlepin/certs/candlepin-ca.crt,mode=0440,type=mount,uid=10001,gid=10000"
+      - "candlepin-ca-key,target=/etc/candlepin/certs/candlepin-ca.key,mode=0440,type=mount,uid=10001,gid=10000"
+      - "candlepin-tomcat-keystore,target=/etc/candlepin/certs/keystore,mode=0440,type=mount,uid=10001,gid=10000"
+      - "candlepin-tomcat-truststore,target=/etc/candlepin/certs/truststore,mode=0440,type=mount,uid=10001,gid=10000"
+      - "candlepin-candlepin-conf,target=/etc/candlepin/candlepin.conf,mode=0440,type=mount,uid=10001,gid=10000"
+      - "candlepin-artemis-broker-xml,target=/etc/candlepin/broker.xml,mode=440,type=mount,uid=10001,gid=10000"
+      - "candlepin-tomcat-server-xml,target={{ candlepin_tomcat_home }}/conf/server.xml,mode=440,type=mount,uid=10001,gid=10000"
+      - "candlepin-artemis-login-config,target={{ candlepin_tomcat_home }}/conf/login.config,mode=440,type=mount,uid=10001,gid=10000"
+      - "candlepin-artemis-cert-roles-properties,target={{ candlepin_tomcat_home }}/conf/cert-roles.properties,mode=440,type=mount,uid=10001,gid=10000"
+      - "candlepin-artemis-cert-users-properties,target={{ candlepin_tomcat_home }}/conf/cert-users.properties,mode=440,type=mount,uid=10001,gid=10000"
+      - "candlepin-artemis-catalina-opts,type=env,target=CATALINA_OPTS"
     quadlet_options:
       - |
         [Install]

--- a/vars/images.yml
+++ b/vars/images.yml
@@ -1,5 +1,5 @@
-candlepin_container_image: quay.io/ehelms/candlepin
-candlepin_container_tag: 4.4.14
+candlepin_container_image: quay.io/candlepin/candlepin
+candlepin_container_tag: 4.4.20-1
 foreman_container_image: "quay.io/evgeni/foreman-rpm"
 foreman_container_tag: "nightly"
 foreman_proxy_container_image: "quay.io/evgeni/foreman-proxy-rpm"


### PR DESCRIPTION
Attempting to use the Candlepin project's official container, but running into errors I do not understand:

```
2025-03-07 02:22:21,154 [thread=Thread-0 (ActiveMQ-server-ActiveMQServerImpl::name=localhost)] [=, org=, csid=] WARN  org.apache.activemq.artemis.core.server - AMQ222216: Security problem while authenticating: AMQ229031: Unable to validate user from invm:0. Username: null; SSL certificate subject DN: unavailable
2025-03-07 02:22:21,156 [thread=main] [=, org=, csid=] WARN  org.candlepin.audit.ArtemisMessageSource - Unable to reconnect message listeners. Messages will not be received: event.default
org.apache.activemq.artemis.api.core.ActiveMQSecurityException: AMQ229031: Unable to validate user from invm:0. Username: null; SSL certificate subject DN: unavailable
```