### PR TITLE
Put Wants= in the correct section

### DIFF
--- a/roles/pulp/tasks/main.yaml
+++ b/roles/pulp/tasks/main.yaml
@@ -74,6 +74,7 @@
       - |
         [Install]
         WantedBy=default.target
+        [Unit]
         Wants=postgresql.service
         [Service]
         Restart=always
@@ -96,6 +97,7 @@
       - |
         [Install]
         WantedBy=default.target
+        [Unit]
         Wants=postgresql.service
         [Service]
         Restart=always
@@ -118,6 +120,7 @@
       - |
         [Install]
         WantedBy=default.target
+        [Unit]
         Wants=postgresql.service
         [Service]
         Restart=always


### PR DESCRIPTION
When inspecting the journal I noticed warnings:

    Unknown key name 'Wants' in section 'Install', ignoring.

The correct section is Unit.

Fixes: fb87fb4a1d0494f964d98fc86cf4d1aafecf0713 ("Change from Pulp all-in-one to split services")