### PR TITLE
Add restart on failure to dynflow services

### DIFF
--- a/roles/foreman/tasks/main.yaml
+++ b/roles/foreman/tasks/main.yaml
@@ -92,6 +92,10 @@
       - |
         [Install]
         WantedBy=default.target
+      - |
+        [Service]
+        RestartPolicy="on-failure"
+        Restart=1
 
 - name: Create Dynflow Container instances
   ansible.builtin.file:


### PR DESCRIPTION
Mirrors configuration from RPM based deployment (https://github.com/theforeman/foreman/blob/develop/extras/systemd/dynflow-sidekiq%40.service#L25-L27) and maybe solves https://github.com/theforeman/foreman-quadlet/issues/112