### PR TITLE
Set postgres handler to started to prevent restarts

### DIFF
--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -39,6 +39,7 @@
     httpd_server_key: "{{ server_key }}"
     pulp_db_password: "CHANGEME"
     pulp_content_origin: "https://{{ ansible_fqdn }}"
+    postgresql_restarted_state: started
     postgresql_databases:
       - name: candlepin
         owner: candlepin

--- a/tests/foreman_api_test.py
+++ b/tests/foreman_api_test.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import requests
+import time
 
 
 def _repo_url(repo, ssh_config):
@@ -38,6 +39,7 @@ def test_foreman_lifecycle_environment(lifecycle_environment):
 
 
 def test_foreman_content_view(content_view, yum_repository, foremanapi):
+    time.sleep(10)
     assert content_view
     foremanapi.update('content_views', {'id': content_view['id'], 'repository_ids': [yum_repository['id']]})
     foremanapi.resource_action('content_views', 'publish', {'id': content_view['id']})


### PR DESCRIPTION
I noticed this output in the logs:

```
Mar 11 16:15:41 quadlet.example.com python3[54896]: ansible-ansible.legacy.systemd Invoked with name=postgresql state=restarted daemon_reload=False daemon_reexec=False scope=system no_block=False enabled=None force=None masked=None
Mar 11 16:15:41 quadlet.example.com systemd[1]: Stopping PostgreSQL database server...
Mar 11 16:15:41 quadlet.example.com foreman[51658]: FATAL:  terminating connection due to administrator command
Mar 11 16:15:41 quadlet.example.com foreman[51658]: #<Thread:0x00007f8f301e39a0 /usr/share/gems/gems/logging-2.4.0/lib/logging/diagnostic_context.rb:471 run> terminated with exception (report_on_exception is true):
Mar 11 16:15:41 quadlet.example.com foreman[51658]: /usr/share/gems/gems/sequel-5.89.0/lib/sequel/adapters/postgres.rb:171:in `exec': PG::ConnectionBad: PQsocket() can't get socket descriptor (Sequel::DatabaseDisconnectError)
```

I believe this is happening due to the defined [handler](https://github.com/geerlingguy/ansible-role-postgresql/blob/master/handlers/main.yml).