### PR TITLE
Split installation into three distinct phases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,6 @@ jobs:
           ansible-playbook playbooks/images.yaml
       - name: Run deployment
         run: |
-          ansible-playbook playbooks/deploy.yaml
+          ansible-playbook playbooks/3-stage-deploy.yaml
       - name: Run tests
         run: ./run_tests

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 host_key_checking = False
+inventory = vagrant.py
 stdout_callback=debug
 stderr_callback=debug
 roles_path = ~/.ansible/roles:./roles

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
 host_key_checking = False
-inventory = vagrant.py
 stdout_callback=debug
 stderr_callback=debug
 roles_path = ~/.ansible/roles:./roles

--- a/playbooks/3-stage-deploy.yaml
+++ b/playbooks/3-stage-deploy.yaml
@@ -1,0 +1,143 @@
+- name: Generate certificates
+  become: true
+  hosts:
+    - quadlet
+  vars_files:
+    - "../vars/{{ certificate_source }}_certificates.yml"
+  vars:
+    certificate_source: default
+    certificates_hostnames:
+      - "{{ ansible_fqdn }}"
+      - localhost
+    certificates_ca_password: "CHANGEME"
+  roles:
+    - role: certificates
+      when: "certificate_source == 'default'"
+    - role: certificate_checks
+      vars:
+        certificate_checks_certificate: "{{ server_certificate }}"
+        certificate_checks_key: "{{ server_key }}"
+        certificate_checks_ca: "{{ ca_certificate }}"
+
+- name: Install server
+  become: true
+  hosts:
+    - quadlet
+  vars_files:
+    - "../vars/{{ certificate_source }}_certificates.yml"
+    - "../vars/images.yml"
+  vars:
+    certificate_source: default
+    candlepin_db_password: "CHANGEME"
+    candlepin_keystore_password: "CHANGEME"
+    candlepin_oauth_secret: "CHANGEME"
+    candlepin_ca_key_password: "{{ ca_key_password }}"
+    candlepin_ca_key: "{{ ca_key }}"
+    candlepin_ca_certificate: "{{ ca_certificate }}"
+    candlepin_tomcat_key: "{{ localhost_key }}"
+    candlepin_tomcat_certificate: "{{ localhost_certificate }}"
+    candlepin_client_key: "{{ client_key }}"
+    candlepin_client_certificate: "{{ client_certificate }}"
+    foreman_ca_certificate: "{{ ca_certificate }}"
+    foreman_client_key: "{{ client_key }}"
+    foreman_client_certificate: "{{ client_certificate }}"
+    foreman_db_password: "CHANGEME"
+    foreman_oauth_consumer_key: abcdefghijklmnopqrstuvwxyz123456
+    foreman_oauth_consumer_secret: abcdefghijklmnopqrstuvwxyz123456
+    httpd_server_ca_certificate: "{{ ca_certificate }}"
+    httpd_client_ca_certificate: "{{ ca_certificate }}"
+    httpd_server_certificate: "{{ server_certificate }}"
+    httpd_server_key: "{{ server_key }}"
+    pulp_db_password: "CHANGEME"
+    pulp_content_origin: "https://{{ ansible_fqdn }}"
+    pulp_pulp_url: "https://{{ ansible_fqdn }}"
+    postgresql_restarted_state: started
+    postgresql_databases:
+      - name: candlepin
+        owner: candlepin
+      - name: foreman
+        owner: foreman
+      - name: pulp
+        owner: pulp
+    postgresql_users:
+      - name: candlepin
+        password: "{{ candlepin_db_password }}"
+      - name: foreman
+        password: "{{ foreman_db_password }}"
+      - name: pulp
+        password: "{{ pulp_db_password }}"
+    postgresql_hba_entries:
+      - { type: local, database: all, user: postgres, auth_method: ident }
+      - { type: local, database: all, user: all, auth_method: ident }
+      - { type: host, database: all, user: postgres, address: '127.0.0.1/32', auth_method: md5 }
+      - { type: host, database: all, user: postgres, address: '0.0.0.0/0', auth_method: reject }
+      - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
+      - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
+  roles:
+    - geerlingguy.postgresql
+    - redis
+    - candlepin
+    - httpd
+    - pulp
+    - foreman
+
+- name: Install smart-proxy
+  become: true
+  hosts:
+    - quadlet
+  vars_files:
+    - "../vars/{{ certificate_source }}_certificates.yml"
+  vars:
+    certificate_source: default
+    foreman_oauth_consumer_key: abcdefghijklmnopqrstuvwxyz123456
+    foreman_oauth_consumer_secret: abcdefghijklmnopqrstuvwxyz123456
+  pre_tasks:
+    - name: Enable foreman-installer PR 1016 Copr repo
+      community.general.copr:
+        host: copr.fedorainfracloud.org
+        state: enabled
+        name: packit/theforeman-foreman-installer-1016
+        chroot: rhel-9-x86_64
+
+    - ansible.builtin.include_role:
+        name: theforeman.operations.puppet_repositories
+      vars:
+        foreman_puppet_repositories_version: "8"
+
+    - ansible.builtin.include_role:
+        name: theforeman.operations.foreman_repositories
+      vars:
+        foreman_repositories_version: nightly
+        foreman_repositories_katello_version: nightly
+
+    - name: Install foreman-proxy
+      package:
+        name: foreman-proxy
+
+    - name: Deploy default certificates
+      ansible.builtin.copy:
+        src: "{{ item.value }}"
+        dest: "{{ item.key }}"
+        remote_src: true
+        owner: foreman-proxy
+        group: foreman-proxy
+        mode: 440
+      loop: "{{ certs | dict2items }}"
+      vars:
+        certs:
+          '/etc/foreman-proxy/foreman_ssl_ca.pem': "{{ ca_certificate }}"
+          '/etc/foreman-proxy/foreman_ssl_cert.pem': "{{ client_certificate }}"
+          '/etc/foreman-proxy/foreman_ssl_key.pem': "{{ client_key }}"
+          '/etc/foreman-proxy/ssl_ca.pem': "{{ ca_certificate }}"
+          '/etc/foreman-proxy/ssl_cert.pem': "{{ server_certificate }}"
+          '/etc/foreman-proxy/ssl_key.pem': "{{ server_key }}"
+  roles:
+    - role: theforeman.operations.installer
+      vars:
+        foreman_installer_scenario: katello
+        foreman_installer_package: foreman-installer-katello
+        foreman_installer_options:
+          - '--foreman-proxy-oauth-consumer-key {{ foreman_oauth_consumer_key }}'
+          - '--foreman-proxy-oauth-consumer-secret {{ foreman_oauth_consumer_secret }}'
+          - '--no-enable-katello'
+          - '--tuning development'

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -35,6 +35,7 @@
     pulp_db_password: "CHANGEME"
     pulp_content_origin: "https://{{ ansible_fqdn }}"
     postgresql_restarted_state: started
+    pulp_pulp_url: "https://{{ ansible_fqdn }}"
     postgresql_databases:
       - name: candlepin
         owner: candlepin

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -58,6 +58,8 @@
       - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
       - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
   roles:
+    - role: foreman_certs
+      when: "certificate_source == 'installer'"
     - role: certificates
       when: "certificate_source == 'default'"
     - role: certificate_checks
@@ -71,3 +73,12 @@
     - httpd
     - pulp
     - foreman
+    - role: theforeman.operations.installer
+      vars:
+        foreman_installer_scenario: katello
+        foreman_installer_package: foreman-installer-katello
+        foreman_installer_options:
+          - '--foreman-proxy-oauth-consumer-key {{ foreman_oauth_consumer_key }}'
+          - '--foreman-proxy-oauth-consumer-secret {{ foreman_oauth_consumer_secret }}'
+          - '--tuning development'
+      when: "certificate_source == 'installer'"

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -22,11 +22,6 @@
     candlepin_tomcat_certificate: "{{ localhost_certificate }}"
     candlepin_client_key: "{{ client_key }}"
     candlepin_client_certificate: "{{ client_certificate }}"
-    foreman_proxy_ca_certificate: "{{ ca_certificate }}"
-    foreman_proxy_server_key: "{{ server_key }}"
-    foreman_proxy_server_certificate: "{{ server_certificate }}"
-    foreman_proxy_client_key: "{{ client_key }}"
-    foreman_proxy_client_certificate: "{{ client_certificate }}"
     foreman_ca_certificate: "{{ ca_certificate }}"
     foreman_client_key: "{{ client_key }}"
     foreman_client_certificate: "{{ client_certificate }}"
@@ -74,5 +69,4 @@
     - candlepin
     - httpd
     - pulp
-    - foreman_proxy
     - foreman

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Setup quadlet demo machine
   hosts:
-    - quadlet
+    - localhost
   become: true
   vars_files:
     - "../vars/{{ certificate_source }}_certificates.yml"

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -36,6 +36,7 @@
     pulp_content_origin: "https://{{ ansible_fqdn }}"
     postgresql_restarted_state: started
     pulp_pulp_url: "https://{{ ansible_fqdn }}"
+    postgresql_restarted_state: started
     postgresql_databases:
       - name: candlepin
         owner: candlepin

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,7 @@ collections:
   - name: containers.podman
     version: ">=1.14.0"
   - name: theforeman.foreman
+  - name: theforeman.operations
   - name: https://github.com/theforeman/forklift
     type: git
 

--- a/roles/foreman/tasks/main.yaml
+++ b/roles/foreman/tasks/main.yaml
@@ -144,7 +144,7 @@
 - name: Configure Foreman Proxy
   theforeman.foreman.smart_proxy:
     name: "{{ ansible_fqdn }}"
-    url: "https://{{ ansible_fqdn }}:9090"
+    url: "https://{{ ansible_fqdn }}/pulp/api/v3/smart_proxy"
     server_url: "http://{{ ansible_fqdn }}:3000"
     username: admin
     password: changeme

--- a/roles/foreman/tasks/main.yaml
+++ b/roles/foreman/tasks/main.yaml
@@ -143,7 +143,7 @@
 
 - name: Configure Foreman Proxy
   theforeman.foreman.smart_proxy:
-    name: "{{ ansible_fqdn }}"
+    name: "{{ ansible_fqdn }}-pulp"
     url: "https://{{ ansible_fqdn }}/pulp/api/v3/smart_proxy"
     server_url: "http://{{ ansible_fqdn }}:3000"
     username: admin

--- a/roles/foreman_certs/tasks/main.yml
+++ b/roles/foreman_certs/tasks/main.yml
@@ -1,0 +1,3 @@
+# utilize https://github.com/theforeman/foreman-installer/pull/935
+- name: Generate certs
+  ansible.builtin.command: foreman-certs --apache true --foreman true --candlepin true --foreman-proxy true

--- a/roles/pulp/defaults/main.yaml
+++ b/roles/pulp/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-pulp_image: quay.io/pulp/pulp-minimal:3.63
+pulp_image: quay.io/evgeni/pulp-smart:latest
 pulp_api_image: "{{ pulp_image }}"
 pulp_content_image: "{{ pulp_image }}"
 pulp_worker_image: "{{ pulp_image }}"

--- a/roles/pulp/defaults/main.yaml
+++ b/roles/pulp/defaults/main.yaml
@@ -15,5 +15,6 @@ pulp_worker_container_name: pulp-worker
 
 pulp_content_origin: "http://{{ ansible_fqdn }}:24816"
 pulp_rhsm_url: "https://{{ ansible_fqdn }}/rhsm"
+pulp_pulp_url: "http://{{ ansible_fqdn }}:24817"
 
 pulp_enable_analytics: false

--- a/roles/pulp/defaults/main.yaml
+++ b/roles/pulp/defaults/main.yaml
@@ -14,5 +14,6 @@ pulp_content_container_name: pulp-content
 pulp_worker_container_name: pulp-worker
 
 pulp_content_origin: "http://{{ ansible_fqdn }}:24816"
+pulp_rhsm_url: "https://{{ ansible_fqdn }}/rhsm"
 
 pulp_enable_analytics: false

--- a/roles/pulp/templates/settings.py.j2
+++ b/roles/pulp/templates/settings.py.j2
@@ -20,3 +20,4 @@ REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES=('rest_framework.authentication.S
 ANALYTICS = {{ pulp_enable_analytics | ternary('True', 'False') }}
 
 SMART_PROXY_RHSM_URL="{{ pulp_rhsm_url }}"
+SMART_PROXY_PULP_URL="{{ pulp_pulp_url }}"

--- a/roles/pulp/templates/settings.py.j2
+++ b/roles/pulp/templates/settings.py.j2
@@ -18,3 +18,5 @@ AUTHENTICATION_BACKENDS=['pulpcore.app.authentication.PulpNoCreateRemoteUserBack
 REMOTE_USER_ENVIRON_NAME="HTTP_REMOTE_USER"
 REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES=('rest_framework.authentication.SessionAuthentication', 'pulpcore.app.authentication.PulpRemoteUserAuthentication')
 ANALYTICS = {{ pulp_enable_analytics | ternary('True', 'False') }}
+
+SMART_PROXY_RHSM_URL="{{ pulp_rhsm_url }}"

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -7,6 +7,32 @@ FOREMAN_PROXY_HOST = 'localhost'
 FOREMAN_PROXY_PORT = 9090
 
 
+@pytest.fixture(scope="module")
+def foreman_proxy_version_curl(server):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/version")
+
+
+@pytest.fixture(scope="module")
+def foreman_proxy_features_curl(server, certificates):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --cert {certificates['client_certificate']} --key {certificates['client_key']} https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/v2/features")
+
+
+def test_foreman_proxy_service(server):
+    foreman_proxy = server.service("foreman-proxy")
+    assert foreman_proxy.is_running
+    assert foreman_proxy.is_enabled
+
+
 def test_foreman_proxy_port(server):
     foreman_proxy = server.addr(FOREMAN_PROXY_HOST)
-    assert not foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable
+    assert foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable
+
+
+def test_foreman_proxy_version(foreman_proxy_version_curl):
+    assert foreman_proxy_version_curl.succeeded
+    assert foreman_proxy_version_curl.stderr == '200'
+
+
+def test_foreman_proxy_features(foreman_proxy_features_curl):
+    assert foreman_proxy_features_curl.succeeded
+    assert foreman_proxy_features_curl.stderr == '200'

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -7,37 +7,6 @@ FOREMAN_PROXY_HOST = 'localhost'
 FOREMAN_PROXY_PORT = 9090
 
 
-@pytest.fixture(scope="module")
-def foreman_proxy_version_curl(server):
-    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/version")
-
-
-@pytest.fixture(scope="module")
-def foreman_proxy_features_curl(server, certificates):
-    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --cert {certificates['client_certificate']} --key {certificates['client_key']} https://{FOREMAN_PROXY_HOST}:{FOREMAN_PROXY_PORT}/v2/features")
-
-
-def test_foreman_proxy_service(server):
-    foreman_proxy = server.service("foreman-proxy")
-    assert foreman_proxy.is_running
-    assert foreman_proxy.is_enabled
-
-
 def test_foreman_proxy_port(server):
     foreman_proxy = server.addr(FOREMAN_PROXY_HOST)
-    assert foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable
-
-
-def test_foreman_proxy_version(foreman_proxy_version_curl):
-    assert foreman_proxy_version_curl.succeeded
-    assert foreman_proxy_version_curl.stderr == '200'
-
-
-def test_foreman_proxy_features(foreman_proxy_features_curl):
-    assert foreman_proxy_features_curl.succeeded
-    assert foreman_proxy_features_curl.stderr == '200'
-
-
-def test_pulpcore_feature(foreman_proxy_features_curl):
-    features = json.loads(foreman_proxy_features_curl.stdout)
-    assert 'pulpcore' in features.keys()
+    assert not foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable

--- a/vars/default_certificates.yml
+++ b/vars/default_certificates.yml
@@ -1,4 +1,5 @@
 ---
+certificates_ca_directory: "/root/certificates"
 ca_key_password: "{{ certificates_ca_directory }}/private/ca.pwd"
 ca_certificate: "{{ certificates_ca_directory }}/certs/ca.crt"
 ca_key: "{{ certificates_ca_directory }}/private/ca.key"

--- a/vars/images.yml
+++ b/vars/images.yml
@@ -4,7 +4,7 @@ foreman_container_image: "quay.io/evgeni/foreman-rpm"
 foreman_container_tag: "nightly"
 foreman_proxy_container_image: "quay.io/evgeni/foreman-proxy-rpm"
 foreman_proxy_container_tag: "nightly"
-pulp_image: quay.io/pulp/pulp-minimal:3.63
+pulp_image: quay.io/evgeni/pulp-smart:latest
 redis_image: quay.io/sclorg/redis-6-c9s:latest
 
 images:


### PR DESCRIPTION
Another look at splitting the installation process into three distinct phases. This does use Ansible, but that's just to help orchestrate and automate for testing purposes. The playbook is split into three sections:

1. Generate default certificates
2. Install the server w/ quadlets using foreman-quadlets
3. Install foreman-proxy using the foreman-installer based on https://github.com/theforeman/foreman-installer/pull/1016

~~The foreman-proxy is not optional at this point. That would require https://github.com/theforeman/foreman-quadlet/pull/81~~

I rebased this on https://github.com/theforeman/foreman-quadlet/pull/105 to have the Pulp smart-proxy and thus make the stand-alone smart-proxy optional.