### PR TITLE
Add documentation for container builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,12 @@ on:
     paths-ignore:
       - 'container-images/**'
       - '.github/workflows/container.yml'
+      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'container-images/**'
       - '.github/workflows/container.yml'
+      - 'docs/**'
 
 
 concurrency:

--- a/docs/container-image-builds.md
+++ b/docs/container-image-builds.md
@@ -1,0 +1,39 @@
+# Container Builds
+
+All container images Foreman builds will live at `quay.io/foreman/$service:$tag`.
+Dependent services that we do not build ourselves will have a copy of containers stored in Foreman’s quay.io to allow tagging with the Foreman version.
+
+There will be three flavors of Foreman containers:
+
+  * Vanilla Foreman
+  * Foreman + Katello
+  * Foreman + all plugins
+
+Stage versions of containers will have stage in the name and be published in the Foreman's quay repository:
+
+  * `quay.io/foreman/$service-stage:$tag`
+
+The base image will be `quay.io/centos/centos:stream9`.
+
+## Containerfile Artifacts
+
+Container files will be stored in repositories for each service that mimic packaging.
+
+  * foreman-oci-images
+  * pulpcore-oci-images
+  * candlepin-oci-images
+
+## Container Image Tagging
+
+The tagging rules for release containers images:
+
+  * Project version - X.Y.Z
+  * Project version - X.Y
+  * Foreman version - X.Y
+  * Foreman version - X.Y.Z
+
+The tagging rules for nightly container images:
+
+  * nightly
+  * Project version X.Y.Z
+


### PR DESCRIPTION
This may not be the long term place we want to store these documents. In the short term, this feels like the right place.

This a lightweight copying of container build strategy that came out of some in person conversations.