### PR TITLE
Abstract away Vagrant as the VM provider to speed up subsequent calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,7 @@ jobs:
         run: ansible-galaxy install -r requirements.yml
       - name: Start VMs
         run: |
-          vagrant up quadlet
-          vagrant up client
+          ./start-vms
       - name: Run setup
         run: |
           ansible-playbook playbooks/setup.yaml

--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ This repository is testing a deployment of Foreman and Katello using Podman quad
 This setup uses Vagrant to create a basic VM for running the deployment on:
 
 ```
-vagrant up quadlet
+./start-vms
 ansible-galaxy install -r requirements.yml
 ansible-playbook playbooks/setup.yaml
 ansible-playbook playbooks/deploy.yaml
+```
+
+To teardown the environment:
+
+```
+./stop-vms
 ```
 
 ## Testing

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 host_key_checking = False
-inventory = vagrant.py
+inventory = inventories/
 stdout_callback=debug
 stderr_callback=debug
 roles_path = ~/.ansible/roles:./roles

--- a/start-vms
+++ b/start-vms
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p inventories
+vagrant up $@
+
+./vagrant.py --yaml > inventories/local_vagrant

--- a/stop-vms
+++ b/stop-vms
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+vagrant destroy -f $@
+rm -f inventories/local_vagrant

--- a/vagrant.py
+++ b/vagrant.py
@@ -9,6 +9,7 @@ import json
 import os
 import subprocess
 import sys
+import yaml
 
 try:
     from StringIO import StringIO  # pyright: reportMissingImports=false
@@ -28,6 +29,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Vagrant inventory script")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--list', action='store_true')
+    group.add_argument('--yaml', action='store_true')
     group.add_argument('--host')
     return parser.parse_args()
 
@@ -109,11 +111,25 @@ def get_configs(hosts):
         yield host, details
 
 
+def format_inventory():
+    hosts = list(get_running_hosts())
+    variables = dict(get_configs(hosts))
+
+    return {
+        "all": {
+            "hosts": variables,
+        },
+    }
+
+
 def main():
     args = parse_args()
     if args.list:
         hosts = list_running_hosts()
         json.dump(hosts, sys.stdout)
+    elif args.yaml:
+        inventory = format_inventory()
+        print(yaml.dump(inventory))
     elif args.host:
         details = dict(get_configs([args.host]))
         json.dump(details[args.host], sys.stdout)


### PR DESCRIPTION
Introduces a script to start and stop VMs and produce a static inventory. This speeds up each call after the fact and creates less reliance on Vagrant.