### PR TITLE
Add debug script to easily print secrets

### DIFF
--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -54,6 +54,10 @@
         password: "{{ foreman_db_password }}"
       - name: pulp
         password: "{{ pulp_db_password }}"
+  pre_tasks:
+    - name: Deploy debug_tools
+      ansible.builtin.include_role:
+        name: debug_tools
   roles:
     - role: certificates
       when: "certificate_source == 'default'"

--- a/roles/debug_tools/files/podman-print-secret
+++ b/roles/debug_tools/files/podman-print-secret
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+podman secret inspect --showsecret --format '{{.SecretData}}' "$1"

--- a/roles/debug_tools/tasks/main.yml
+++ b/roles/debug_tools/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install podman-print-secret tool
+  ansible.builtin.copy:
+    src: podman-print-secret
+    dest: /usr/local/bin/podman-print-secret
+    mode: '0755'


### PR DESCRIPTION
This is helpful for debugging as it allows easily printing a secret.

```
print-secret candlepin-candlepin-conf
```