### PR TITLE
Add all database variables for Foreman, Candlepin and Pulp

### DIFF
--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - "../vars/{{ certificate_source }}_certificates.yml"
     - "../vars/images.yml"
+    - "../vars/database.yml"
   vars:
     certificate_source: default
     certificates_hostnames:
       - "{{ ansible_fqdn }}"
       - localhost
     certificates_ca_password: "CHANGEME"
-    candlepin_db_password: "CHANGEME"
     candlepin_keystore_password: "CHANGEME"
     candlepin_oauth_secret: "CHANGEME"
     candlepin_ca_key_password: "{{ ca_key_password }}"
@@ -30,30 +30,13 @@
     foreman_ca_certificate: "{{ ca_certificate }}"
     foreman_client_key: "{{ client_key }}"
     foreman_client_certificate: "{{ client_certificate }}"
-    foreman_db_password: "CHANGEME"
     foreman_oauth_consumer_key: abcdefghijklmnopqrstuvwxyz123456
     foreman_oauth_consumer_secret: abcdefghijklmnopqrstuvwxyz123456
     httpd_server_ca_certificate: "{{ ca_certificate }}"
     httpd_client_ca_certificate: "{{ ca_certificate }}"
     httpd_server_certificate: "{{ server_certificate }}"
     httpd_server_key: "{{ server_key }}"
-    pulp_db_password: "CHANGEME"
     pulp_content_origin: "https://{{ ansible_fqdn }}"
-    postgresql_restarted_state: started
-    postgresql_databases:
-      - name: candlepin
-        owner: candlepin
-      - name: foreman
-        owner: foreman
-      - name: pulp
-        owner: pulp
-    postgresql_users:
-      - name: candlepin
-        password: "{{ candlepin_db_password }}"
-      - name: foreman
-        password: "{{ foreman_db_password }}"
-      - name: pulp
-        password: "{{ pulp_db_password }}"
   pre_tasks:
     - name: Deploy debug_tools
       ansible.builtin.include_role:

--- a/roles/candlepin/defaults/main.yml
+++ b/roles/candlepin/defaults/main.yml
@@ -15,8 +15,10 @@ candlepin_ciphers:
 candlepin_container_image: quay.io/ehelms/candlepin
 candlepin_container_tag: 4.4.14
 
-candlepin_db_host: localhost
-candlepin_db_port: 5432
-candlepin_db_ssl: false
-candlepin_db_ssl_ca: None
-candlepin_db_ssl_verify: true
+candlepin_database_host: localhost
+candlepin_database_port: 5432
+candlepin_database_ssl: false
+candlepin_database_ssl_mode: disable
+candlepin_database_ssl_ca:
+candlepin_database_ssl_cert:
+candlepin_database_ssl_key:

--- a/roles/candlepin/templates/candlepin.conf.j2
+++ b/roles/candlepin/templates/candlepin.conf.j2
@@ -20,10 +20,10 @@ candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=0 0 0 * * ?
 
 jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 jpa.config.hibernate.hbm2ddl.auto=validate
-jpa.config.hibernate.connection.username=candlepin
-jpa.config.hibernate.connection.password={{ candlepin_db_password }}
+jpa.config.hibernate.connection.username={{ candlepin_database_user }}
+jpa.config.hibernate.connection.password={{ candlepin_database_password }}
 jpa.config.hibernate.connection.driver_class=org.postgresql.Driver
-jpa.config.hibernate.connection.url=jdbc:postgresql://{{ candlepin_db_host }}:{{ candlepin_db_port }}/candlepin{% if candlepin_db_ssl %}?ssl=true{% endif %}{% if candlepin_db_ssl and candlepin_db_ssl_ca is defined %}&sslrootcert={{ candlepin_db_ssl_ca }}{% endif %}{% if not candlepin_db_ssl_verify and candlepin_db_ssl %}&sslfactory=org.postgresql.ssl.NonValidatingFactory{% endif %}
+jpa.config.hibernate.connection.url=jdbc:postgresql://{{ candlepin_database_host }}:{{ candlepin_database_port }}/{{ candlepin_database_name }}?sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}
 
 
 org.quartz.jobStore.misfireThreshold=60000
@@ -34,7 +34,7 @@ org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
 org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
 
 org.quartz.dataSource.myDS.driver=org.postgresql.Driver
-org.quartz.dataSource.myDS.user=candlepin
-org.quartz.dataSource.myDS.password={{ candlepin_db_password }}
+org.quartz.dataSource.myDS.user={{ candlepin_database_user }}
+org.quartz.dataSource.myDS.password={{ candlepin_database_password }}
 org.quartz.dataSource.myDS.maxConnections=5
-org.quartz.dataSource.myDS.URL=jdbc:postgresql://{{ candlepin_db_host }}:{{ candlepin_db_port }}/candlepin{% if candlepin_db_ssl %}?ssl=true{% endif %}{% if candlepin_db_ssl and candlepin_db_ssl_ca is defined %}&sslrootcert={{ candlepin_db_ssl_ca }}{% endif %}{% if not candlepin_db_ssl_verify and candlepin_db_ssl %}&sslfactory=org.postgresql.ssl.NonValidatingFactory{% endif %}
+org.quartz.dataSource.myDS.URL=jdbc:postgresql://{{ candlepin_database_host }}:{{ candlepin_database_port }}/{{ candlepin_database_name }}?sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}

--- a/roles/foreman/defaults/main.yaml
+++ b/roles/foreman/defaults/main.yaml
@@ -1,3 +1,11 @@
 ---
 foreman_container_image: "quay.io/evgeni/foreman-rpm"
 foreman_container_tag: "nightly"
+
+foreman_database_name: foreman
+foreman_database_user: foreman
+foreman_database_host: localhost
+foreman_database_port: 5432
+foreman_database_pool: 9
+foreman_database_sslmode: disable
+foreman_database_sslrootcert:

--- a/roles/foreman/tasks/main.yaml
+++ b/roles/foreman/tasks/main.yaml
@@ -8,7 +8,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-database-url
-    data: "postgresql://foreman:{{ foreman_db_password }}@localhost/foreman"
+    data: "postgresql://{{ foreman_database_user }}:{{ foreman_database_password }}@{{ foreman_database_host }}:{{ foreman_database_port }}/{{ foreman_database_name }}?pool={{ foreman_database_pool }}&sslmode={{ foreman_database_sslmode }}{% if foreman_database_ssl_ca is defined %}&sslrootcert={{ foreman_database_ssl_ca }}{% endif %}" # yamllint disable-line rule:line-length
 
 - name: Create settings config secret
   containers.podman.podman_secret:

--- a/roles/pulp/defaults/main.yaml
+++ b/roles/pulp/defaults/main.yaml
@@ -17,11 +17,20 @@ pulp_content_origin: "http://{{ ansible_fqdn }}:24816"
 
 pulp_enable_analytics: false
 
-pulp_settings_db_env:
-  PULP_DATABASES__default__HOST: "localhost"
-  PULP_DATABASES__default__NAME: "pulp"
-  PULP_DATABASES__default__PORT: 5432
-  PULP_DATABASES__default__USER: "pulp"
+pulp_database_name: pulp
+pulp_database_user: pulp
+pulp_database_host: localhost
+pulp_database_port: 5432
+pulp_database_ssl_mode: disabled
+pulp_database_ssl_ca: None
+
+pulp_settings_database_env:
+  PULP_DATABASES__default__NAME: "{{ pulp_database_name }}"
+  PULP_DATABASES__default__USER: "{{ pulp_database_user }}"
+  PULP_DATABASES__default__HOST: "{{ pulp_database_host }}"
+  PULP_DATABASES__default__PORT: "{{ pulp_database_port }}"
+  PULP_DATABASES__default__OPTIONS__sslmode: "{{ pulp_database_ssl_mode }}"
+  PULP_DATABASES__default__OPTIONS__sslrootcert: "{{ pulp_database_ssl_ca }}"
 
 # The arrays (AUTH_BACKENDS, AUTH_CLASSES) need to contain literal quotes
 # to workaround https://github.com/containers/ansible-podman-collections/issues/807
@@ -37,4 +46,4 @@ pulp_settings_other_env:
   PULP_REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES: >-
     "['rest_framework.authentication.SessionAuthentication', 'pulpcore.app.authentication.PulpRemoteUserAuthentication']"
 
-pulp_settings_env: "{{ pulp_settings_db_env | ansible.builtin.combine(pulp_settings_other_env) }}"
+pulp_settings_env: "{{ pulp_settings_database_env | ansible.builtin.combine(pulp_settings_other_env) }}"

--- a/roles/pulp/tasks/main.yaml
+++ b/roles/pulp/tasks/main.yaml
@@ -34,7 +34,7 @@
   containers.podman.podman_secret:
     state: present
     name: pulp-db-password
-    data: "{{ pulp_db_password }}"
+    data: "{{ pulp_database_password }}"
 
 - name: Generate database symmetric key
   ansible.builtin.command: "bash -c 'openssl rand -base64 32 | tr \"+/\" \"-_\" > /var/lib/pulp/database_fields.symmetric.key'"
@@ -132,7 +132,7 @@
     secrets:
       - 'pulp-symmetric-key,type=mount,target=/etc/pulp/certs/database_fields.symmetric.key'
       - 'pulp-db-password,type=env,target=PULP_DATABASES__default__PASSWORD'
-    env: "{{ pulp_settings_db_env }}"
+    env: "{{ pulp_settings_database_env }}"
 
 - name: Start the Pulp API services
   ansible.builtin.systemd:

--- a/vars/database.yml
+++ b/vars/database.yml
@@ -1,0 +1,46 @@
+---
+database_mode: internal
+database_host: localhost
+database_port: 5432
+database_ssl_mode: disable
+database_ssl_ca: None
+
+foreman_database_name: foreman
+foreman_database_user: foreman
+foreman_database_password: CHANGEME
+candlepin_database_name: candlepin
+candlepin_database_user: candlepin
+candlepin_database_password: CHANGEME
+pulp_database_name: pulp
+pulp_database_user: pulp
+pulp_database_password: CHANGEME
+
+candlepin_database_host: "{{ database_host }}"
+candlepin_database_port: "{{ database_port }}"
+candlepin_database_ssl_mode: "{{ database_ssl_mode }}"
+candlepin_database_ssl_ca: "{{ database_ssl_ca }}"
+
+pulp_database_host: "{{ database_host }}"
+pulp_database_port: "{{ database_port }}"
+pulp_database_ssl_mode: "{{ database_ssl_mode }}"
+pulp_database_ssl_ca: "{{ database_ssl_ca }}"
+
+foreman_database_host: "{{ database_host }}"
+foreman_database_port: "{{ database_port }}"
+foreman_database_sslmode: "{{ database_ssl_mode }}"
+foreman_database_sslrootcert: "{{ database_ssl_ca }}"
+
+postgresql_databases:
+  - name: "{{ candlepin_database_name }}"
+    owner: "{{ candlepin_database_user }}"
+  - name: "{{ foreman_database_name }}"
+    owner: "{{ foreman_database_user }}"
+  - name: "{{ pulp_database_name }}"
+    owner: "{{ pulp_database_user }}"
+postgresql_users:
+  - name: "{{ candlepin_database_name }}"
+    password: "{{ candlepin_database_password }}"
+  - name: "{{ foreman_database_name }}"
+    password: "{{ foreman_database_password }}"
+  - name: "{{ pulp_database_name }}"
+    password: "{{ pulp_database_password }}"


### PR DESCRIPTION
This does include SSL variables, but not SSL testing for PostgreSQL access. I think that will require quite a bit extra to spin up a variation of testing that include those. This PR is instead intended to centralize the database variables to a single set of inputs, that I can then use with Obsah (https://github.com/theforeman/obsah/pull/63) to do variable combining and mutual requirement testing on top of https://github.com/theforeman/foreman-quadlet/pull/13.