### PR TITLE
Add RPM spec and packit config

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,13 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rop.spec
+
+upstream_package_name: rop
+downstream_package_name: rop
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - epel-9

--- a/rop
+++ b/rop
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 OBSAH_NAME=rop
-OBSAH_DATA=src
-OBSAH_INVENTORY=./inventories/
+OBSAH_BASE=.
+OBSAH_DATA=${OBSAH_BASE}/src
+OBSAH_INVENTORY=${OBSAH_BASE}/inventories
 export OBSAH_NAME OBSAH_DATA OBSAH_INVENTORY
 
 exec obsah "$@"

--- a/rop.spec
+++ b/rop.spec
@@ -1,0 +1,56 @@
+Name:      rop
+Version:   0.0.1
+Release:   0%{?dist}
+Summary:   Install Foreman using containers
+
+License:   GPL-2-only
+URL:       https://github.com/theforeman/foreman-quadlet
+Source:    https://github.com/theforeman/foreman-quadlet/releases/download/%{version}/%{name}-%{version}.tar.gz
+
+BuildArch: noarch
+Requires:  ansible-collection-ansible-posix
+Requires:  ansible-collection-community-crypto
+Requires:  ansible-collection-community-general
+Requires:  ansible-collection-community-postgresql
+Requires:  ansible-collection-containers-podman >= 1.14.0
+Requires:  ansible-collection-theforeman-foreman
+Requires:  ansible-collection-theforeman-operations
+Requires:  python3-obsah >= 1.1
+
+# These are needed on the target host, which is usually localhost
+Recommends:  podman
+Recommends:  python3-libsemanage
+Recommends:  python3-psycopg2
+
+# Tab completion is nice to have
+Suggests:  bash-completion
+Suggests:  python3-argcomplete
+
+%description
+Install Foreman using containers. They are deployed as podman quadlets.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+cat > inventories/quadlet <<INVENTORY
+[quadlet]
+localhost ansible_connection=local
+INVENTORY
+
+sed -i '/^OBSAH_BASE=/ s|=.\+|=%{_datadir}/%{name}|' rop
+
+%install
+install -d -m0755 %{buildroot}%{_datadir}/%{name}
+install -d -m0755 %{buildroot}%{_bindir}
+
+cp -r inventories src %{buildroot}%{_datadir}/%{name}
+cp -r rop %{buildroot}%{_bindir}/%{name}
+
+
+%files
+%{_bindir}/rop
+%{_datadir}/%{name}
+
+
+%changelog

--- a/rop.spec
+++ b/rop.spec
@@ -14,7 +14,6 @@ Requires:  ansible-collection-community-general
 Requires:  ansible-collection-community-postgresql
 Requires:  ansible-collection-containers-podman >= 1.14.0
 Requires:  ansible-collection-theforeman-foreman
-Requires:  ansible-collection-theforeman-operations
 Requires:  python3-obsah >= 1.1
 
 # These are needed on the target host, which is usually localhost


### PR DESCRIPTION
This builds on https://github.com/theforeman/foreman-quadlet/pull/131 and adds an RPM spec file with packit configuration.

<del>Right now it won't include any of the galaxy modules we depend on and we need to have a discussion on how to resolve that. Will we vendor those into the Python package or list them separate in the RPM spec file?</del>