### PR TITLE
Stop setting a fixed password for Pulp admin user

### DIFF
--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -164,8 +164,7 @@
     enabled: true
     state: started
 
-# Only needed until we have cert auth configured
-- name: Set Pulp admin password
+- name: Ensure Pulp admin user exists
   containers.podman.podman_container_exec:
     name: "{{ pulp_api_container_name }}"
-    command: pulpcore-manager reset-admin-password --password CHANGEME
+    command: pulpcore-manager reset-admin-password --random

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -59,11 +59,6 @@ def test_pulp_status_content(pulp_status):
 def test_pulp_status_workers(pulp_status):
     assert pulp_status['online_workers']
 
-@pytest.mark.xfail(reason='password auth is deactivated when we use cert auth')
-def test_pulp_admin_auth(server):
-    cmd = server.run(f"curl --silent --write-out '%{{stderr}}%{{http_code}}' --user admin:CHANGEME http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/users/")
-    assert cmd.succeeded
-    assert cmd.stderr == '200'
 
 def test_pulp_volumes(server):
     assert server.file("/var/lib/pulp").is_directory


### PR DESCRIPTION
This was needed before we had cert auth.

Fixes: 2ad1ca5343aa ("configure cert auth for pulp")