### PR TITLE
Rely on sdnotify: true for pulp

### DIFF
--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -137,23 +137,27 @@
       - 'pulp-db-password,type=env,target=PULP_DATABASES__default__PASSWORD'
     env: "{{ pulp_settings_database_env }}"
 
-- name: Start the Pulp API services
+- name: Start Pulp services
   ansible.builtin.systemd:
-    name: pulp-api
+    name: "{{ item }}"
     enabled: true
     state: started
+  async: 60
+  poll: 0
+  loop:
+    - pulp-api
+    - pulp-content
+    - pulp-worker
+  register: pulp_services
 
-- name: Start the Pulp Content services
-  ansible.builtin.systemd:
-    name: pulp-content
-    enabled: true
-    state: started
-
-- name: Start the Pulp Worker service
-  ansible.builtin.systemd:
-    name: pulp-worker
-    enabled: true
-    state: started
+- name: Wait for Pulp services
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: job_result
+  until: job_result is finished
+  retries: 100
+  delay: 1
+  loop: "{{ pulp_services.results }}"
 
 - name: Ensure Pulp admin user exists
   containers.podman.podman_container_exec:

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -52,6 +52,7 @@
     name: "{{ pulp_api_container_name }}"
     image: "{{ pulp_api_image }}"
     state: quadlet
+    sdnotify: true
     command: pulp-api
     network: host
     volumes: "{{ pulp_volumes }}"
@@ -76,6 +77,7 @@
     name: "{{ pulp_content_container_name }}"
     image: "{{ pulp_content_image }}"
     state: quadlet
+    sdnotify: true
     command: pulp-content
     network: host
     volumes: "{{ pulp_volumes }}"
@@ -141,23 +143,11 @@
     enabled: true
     state: started
 
-- name: Wait for Pulp API service to be accessible
-  ansible.builtin.wait_for:
-    host: "{{ ansible_fqdn}}"
-    port: 24817
-    timeout: 300
-
 - name: Start the Pulp Content services
   ansible.builtin.systemd:
     name: pulp-content
     enabled: true
     state: started
-
-- name: Wait for Pulp Content service to be accessible
-  ansible.builtin.wait_for:
-    host: "{{ ansible_fqdn }}"
-    port: 24816
-    timeout: 600
 
 - name: Start the Pulp Worker service
   ansible.builtin.systemd:

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -128,6 +128,7 @@
     name: pulpcore-manager-migrate
     image: "{{ pulp_api_image }}"
     command: pulpcore-manager migrate --noinput
+    detach: false
     network: host
     secrets:
       - 'pulp-symmetric-key,type=mount,target=/etc/pulp/certs/database_fields.symmetric.key'


### PR DESCRIPTION
This relies on using systemd notification support to signal a service is ready. That means we no longer need to wait for it to be listening and they can start in parallel.

For that we need to wait for the migration to complete, which is important. Otherwise steps after it may run that depend on a migrated database.

Split off from https://github.com/theforeman/foreman-quadlet/pull/114