### PR TITLE
Expect status 200 on ping output too

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -138,7 +138,9 @@
 - name: Wait for Foreman tasks to be ready
   ansible.builtin.uri:
     url: 'http://{{ ansible_fqdn }}:3000/api/v2/ping'
-  until: foreman_tasks_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'
+  until:
+    - foreman_tasks_status.status == 200
+    - foreman_tasks_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'
   retries: 60
   delay: 5
   register: foreman_tasks_status


### PR DESCRIPTION
In my testing I sometimes got an error that dict didn't have a json property. I suspect the service returned an error message so this first checks for status 200.